### PR TITLE
Optional behaviour change

### DIFF
--- a/CleanDomainValidation/Application/Classes/ClassProperty.cs
+++ b/CleanDomainValidation/Application/Classes/ClassProperty.cs
@@ -9,8 +9,6 @@ public sealed class ClassProperty<TParameters, TProperty> : IValidatableProperty
 	private IValidatableProperty _property;
 	private TParameters _parameters;
 
-	public bool IsRequired => _property.IsRequired;
-	public bool IsMissing => _property.IsMissing;
 	public CanFail ValidationResult => _property.ValidationResult;
 
 	internal ClassProperty(TParameters parameters)

--- a/CleanDomainValidation/Application/Classes/OptionalClassProperty.cs
+++ b/CleanDomainValidation/Application/Classes/OptionalClassProperty.cs
@@ -6,16 +6,11 @@ public sealed class OptionalClassProperty<TParameters, TProperty> : IValidatable
 	where TParameters : notnull
 	where TProperty : class
 {
-	public bool IsRequired => false;
-
-	public bool IsMissing { get; set; }
-
 	public TParameters Parameters { get; }
 	public CanFail ValidationResult { get; } = new();
 
 	internal OptionalClassProperty(TParameters parameters)
 	{
-		IsMissing = false;
 		Parameters = parameters;
 	}
 }

--- a/CleanDomainValidation/Application/Classes/RequiredClassProperty.cs
+++ b/CleanDomainValidation/Application/Classes/RequiredClassProperty.cs
@@ -7,15 +7,12 @@ public sealed class RequiredClassProperty<TParameters, TProperty> : IValidatable
 	where TParameters : notnull
 	where TProperty : class
 {
-	public bool IsRequired => true;
-	public bool IsMissing { get; set; }
 	public Error MissingError { get; }
 	public TParameters Parameters { get; }
 	public CanFail ValidationResult { get; } = new();
 
 	internal RequiredClassProperty(TParameters parameters, Error missingError)
 	{
-		IsMissing = false;
 		Parameters = parameters;
 		MissingError = missingError;
 	}

--- a/CleanDomainValidation/Application/Enums/EnumProperty.cs
+++ b/CleanDomainValidation/Application/Enums/EnumProperty.cs
@@ -9,8 +9,6 @@ public sealed class EnumProperty<TParameters, TProperty> : IValidatableProperty
 	private IValidatableProperty _property;
 	private TParameters _parameters;
 
-	public bool IsRequired => _property.IsRequired;
-	public bool IsMissing => _property.IsMissing;
 	public CanFail ValidationResult => _property.ValidationResult;
 
 	internal EnumProperty(TParameters parameters)

--- a/CleanDomainValidation/Application/Enums/OptionalEnumProperty.cs
+++ b/CleanDomainValidation/Application/Enums/OptionalEnumProperty.cs
@@ -6,15 +6,11 @@ public sealed class OptionalEnumProperty<TParameters, TProperty> : IValidatableP
 	where TParameters : notnull
 	where TProperty : struct
 {
-	public bool IsRequired => false;
-
-	public bool IsMissing { get; set; }
 	public TParameters Parameters { get; }
 	public CanFail ValidationResult { get; } = new();
 
 	internal OptionalEnumProperty(TParameters parameters)
 	{
-		IsMissing = false;
 		Parameters = parameters;
 	}
 }

--- a/CleanDomainValidation/Application/Enums/RequiredEnumProperty.cs
+++ b/CleanDomainValidation/Application/Enums/RequiredEnumProperty.cs
@@ -6,15 +6,12 @@ public sealed class RequiredEnumProperty<TParameters, TProperty> : IValidatableP
 	where TParameters : notnull
 	where TProperty : struct
 {
-	public bool IsRequired => true;
-	public bool IsMissing { get; set; }
 	public Error MissingError { get; }
 	public TParameters Parameters { get; }
 	public CanFail ValidationResult { get; } = new();
 
 	internal RequiredEnumProperty(TParameters parameters, Error missingError)
 	{
-		IsMissing = false;
 		Parameters = parameters;
 		MissingError = missingError;
 	}

--- a/CleanDomainValidation/Application/Extensions/ComplexMapExtensions.cs
+++ b/CleanDomainValidation/Application/Extensions/ComplexMapExtensions.cs
@@ -18,7 +18,6 @@ public static class ComplexMapExtensions
 		TPropertyParameters? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -44,7 +43,6 @@ public static class ComplexMapExtensions
 		TPropertyParameters? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -70,7 +68,6 @@ public static class ComplexMapExtensions
 		TPropertyParameters? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}
@@ -97,7 +94,6 @@ public static class ComplexMapExtensions
 		TPropertyParameters? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}
@@ -128,7 +124,6 @@ public static class ComplexMapExtensions
 		TPropertyParameters? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -154,7 +149,6 @@ public static class ComplexMapExtensions
 		TPropertyParameters? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -180,7 +174,6 @@ public static class ComplexMapExtensions
 		TPropertyParameters? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -207,7 +200,6 @@ public static class ComplexMapExtensions
 		TPropertyParameters? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -238,7 +230,6 @@ public static class ComplexMapExtensions
 		IEnumerable<TPropertyParameters>? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -268,7 +259,6 @@ public static class ComplexMapExtensions
 		IEnumerable<TPropertyParameters>? builderParameters = propertyParameters.Invoke(property.Parameters);
 		if (builderParameters is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}

--- a/CleanDomainValidation/Application/Extensions/ConstructorMapExtensions.cs
+++ b/CleanDomainValidation/Application/Extensions/ConstructorMapExtensions.cs
@@ -20,7 +20,6 @@ public static class ConstructorMapExtensions
 
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -39,7 +38,6 @@ public static class ConstructorMapExtensions
 
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -57,7 +55,6 @@ public static class ConstructorMapExtensions
 		TValue? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}
@@ -76,7 +73,6 @@ public static class ConstructorMapExtensions
 		TValue? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}
@@ -100,7 +96,6 @@ public static class ConstructorMapExtensions
 
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -119,7 +114,6 @@ public static class ConstructorMapExtensions
 
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -137,7 +131,6 @@ public static class ConstructorMapExtensions
 		TValue? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -156,7 +149,6 @@ public static class ConstructorMapExtensions
 		TValue? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -178,7 +170,6 @@ public static class ConstructorMapExtensions
 		IEnumerable<TValue>? rawValues = values.Invoke(property.Parameters);
 		if (rawValues is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -203,7 +194,6 @@ public static class ConstructorMapExtensions
 		IEnumerable<TValue>? rawValues = values.Invoke(property.Parameters);
 		if (rawValues is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}

--- a/CleanDomainValidation/Application/Extensions/DirectMapExtensions.cs
+++ b/CleanDomainValidation/Application/Extensions/DirectMapExtensions.cs
@@ -14,10 +14,6 @@ public static class DirectMapExtensions
 		where TProperty : class
 	{
 		TProperty? rawValue = value.Invoke(property.Parameters);
-		if(rawValue is null)
-		{
-			property.IsMissing = true;
-		}
 		return rawValue;
 	}
 
@@ -30,7 +26,6 @@ public static class DirectMapExtensions
 		TProperty? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}
@@ -49,10 +44,6 @@ public static class DirectMapExtensions
 		where TProperty : struct
 	{
 		TProperty? rawValue = value.Invoke(property.Parameters);
-		if (rawValue is null)
-		{
-			property.IsMissing = true;
-		}
 		return rawValue;
 	}
 
@@ -65,7 +56,6 @@ public static class DirectMapExtensions
 		TProperty? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -84,10 +74,6 @@ public static class DirectMapExtensions
 		where TProperty : notnull
 	{
 		IEnumerable<TProperty>? rawValue = values.Invoke(property.Parameters);
-		if (rawValue is null)
-		{
-			property.IsMissing = true;
-		}
 
 		return rawValue;
 	}
@@ -101,7 +87,6 @@ public static class DirectMapExtensions
 		IEnumerable<TProperty>? rawValue = values.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}

--- a/CleanDomainValidation/Application/Extensions/EnumMapExtensions.cs
+++ b/CleanDomainValidation/Application/Extensions/EnumMapExtensions.cs
@@ -17,7 +17,6 @@ public static class EnumMapExtensions
 		string? rawEnum = value.Invoke(property.Parameters);
 		if(rawEnum is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -40,7 +39,6 @@ public static class EnumMapExtensions
 		string? rawEnum = value.Invoke(property.Parameters);
 		if (rawEnum is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -64,7 +62,6 @@ public static class EnumMapExtensions
 		int? rawEnum = value.Invoke(property.Parameters);
 		if (rawEnum is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -87,7 +84,6 @@ public static class EnumMapExtensions
 		int? rawEnum = value.Invoke(property.Parameters);
 		if (rawEnum is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -115,7 +111,6 @@ public static class EnumMapExtensions
 		IEnumerable<string>? rawEnums = values.Invoke(property.Parameters);
 		if (rawEnums is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -145,7 +140,6 @@ public static class EnumMapExtensions
 		IEnumerable<string>? rawEnums = values.Invoke(property.Parameters);
 		if (rawEnums is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}
@@ -176,7 +170,6 @@ public static class EnumMapExtensions
 		IEnumerable<int>? rawEnums = values.Invoke(property.Parameters);
 		if (rawEnums is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -206,7 +199,6 @@ public static class EnumMapExtensions
 		IEnumerable<int>? rawEnums = values.Invoke(property.Parameters);
 		if (rawEnums is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}

--- a/CleanDomainValidation/Application/Extensions/FactoryMapExtensions.cs
+++ b/CleanDomainValidation/Application/Extensions/FactoryMapExtensions.cs
@@ -20,7 +20,6 @@ public static class FactoryMapExtensions
 
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -46,7 +45,6 @@ public static class FactoryMapExtensions
 
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -71,7 +69,6 @@ public static class FactoryMapExtensions
 		TValue? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}
@@ -97,7 +94,6 @@ public static class FactoryMapExtensions
 		TValue? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}
@@ -128,7 +124,6 @@ public static class FactoryMapExtensions
 
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -154,7 +149,6 @@ public static class FactoryMapExtensions
 
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -179,7 +173,6 @@ public static class FactoryMapExtensions
 		TValue? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -205,7 +198,6 @@ public static class FactoryMapExtensions
 		TValue? rawValue = value.Invoke(property.Parameters);
 		if (rawValue is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return default;
 		}
@@ -234,7 +226,6 @@ public static class FactoryMapExtensions
 		IEnumerable<TValue>? rawValues = values.Invoke(property.Parameters);
 		if (rawValues is null)
 		{
-			property.IsMissing = true;
 			return null;
 		}
 
@@ -264,7 +255,6 @@ public static class FactoryMapExtensions
 		IEnumerable<TValue>? rawValues = values.Invoke(property.Parameters);
 		if (rawValues is null)
 		{
-			property.IsMissing = true;
 			property.ValidationResult.Failed(property.MissingError);
 			return null!;
 		}

--- a/CleanDomainValidation/Application/IValidatableProperty.cs
+++ b/CleanDomainValidation/Application/IValidatableProperty.cs
@@ -4,7 +4,5 @@ namespace CleanDomainValidation.Application;
 
 public interface IValidatableProperty
 {
-	bool IsRequired { get; }
-	bool IsMissing { get; }
 	CanFail ValidationResult { get; }
 }

--- a/CleanDomainValidation/Application/Lists/ListProperty.cs
+++ b/CleanDomainValidation/Application/Lists/ListProperty.cs
@@ -8,9 +8,6 @@ public sealed class ListProperty<TParameters, TProperty> : IValidatableProperty
 {
 	private IValidatableProperty _property;
 	private TParameters _parameters;
-
-	public bool IsRequired => _property.IsRequired;
-	public bool IsMissing => _property.IsMissing;
 	public CanFail ValidationResult => _property.ValidationResult;
 
 	internal ListProperty(TParameters parameters)

--- a/CleanDomainValidation/Application/Lists/OptionalListProperty.cs
+++ b/CleanDomainValidation/Application/Lists/OptionalListProperty.cs
@@ -6,15 +6,11 @@ public sealed class OptionalListProperty<TParameters, TProperty> : IValidatableP
 	where TParameters : notnull
 	where TProperty : notnull
 {
-	public bool IsRequired => false;
-
-	public bool IsMissing { get; set; }
 	public TParameters Parameters { get; }
 	public CanFail ValidationResult { get; } = new();
 
 	internal OptionalListProperty(TParameters parameters)
 	{
-		IsMissing = false;
 		Parameters = parameters;
 	}
 }

--- a/CleanDomainValidation/Application/Lists/RequiredListProperty.cs
+++ b/CleanDomainValidation/Application/Lists/RequiredListProperty.cs
@@ -6,15 +6,12 @@ public sealed class RequiredListProperty<TParameters, TProperty> : IValidatableP
 	where TParameters : notnull
 	where TProperty : notnull
 {
-	public bool IsRequired => true;
-	public bool IsMissing { get; set; }
 	public Error MissingError { get; }
 	public TParameters Parameters { get; }
 	public CanFail ValidationResult { get; } = new();
 
 	internal RequiredListProperty(TParameters parameters, Error missingError)
 	{
-		IsMissing = false;
 		Parameters = parameters;
 		MissingError = missingError;
 	}

--- a/CleanDomainValidation/Application/OptionalClassPropertyBuilder.cs
+++ b/CleanDomainValidation/Application/OptionalClassPropertyBuilder.cs
@@ -12,24 +12,12 @@ public sealed class OptionalClassPropertyBuilder<TParameters, TResult> : Propert
 	{
 		CanFail<TResult?> result = new();
 
-		bool requiredPropertyMissing = false;
-
 		foreach (var property in Properties)
 		{
-			if(property.IsRequired && property.IsMissing)
-			{
-				requiredPropertyMissing = true;
-				continue;
-			}
 			result.InheritFailure(property.ValidationResult);
 		}
 
-		if(!result.HasFailed && requiredPropertyMissing)
-		{
-			result.Succeeded(null);
-		}
-
-		if (!result.HasFailed && !requiredPropertyMissing)
+		if (!result.HasFailed)
 		{
 			result.Succeeded(creationMethod.Invoke());
 		}
@@ -41,27 +29,14 @@ public sealed class OptionalClassPropertyBuilder<TParameters, TResult> : Propert
 	{
 		CanFail<TResult?> result = new();
 
-		bool requiredPropertyMissing = false;
-
 		foreach (var property in Properties)
 		{
-			if (property.IsRequired && property.IsMissing)
-			{
-				requiredPropertyMissing = true;
-				continue;
-			}
 			result.InheritFailure(property.ValidationResult);
 		}
 
 		//Ensure the factory method wont get called if any errors occured to the parameters
 		if (result.HasFailed)
 		{
-			return new ValidatedOptionalClassProperty<TResult>(result);
-		}
-
-		if (requiredPropertyMissing)
-		{
-			result.Succeeded(null);
 			return new ValidatedOptionalClassProperty<TResult>(result);
 		}
 

--- a/CleanDomainValidation/Application/OptionalStructPropertyBuilder.cs
+++ b/CleanDomainValidation/Application/OptionalStructPropertyBuilder.cs
@@ -12,24 +12,13 @@ public sealed class OptionalStructPropertyBuilder<TParameters, TResult> : Proper
 	{
 		CanFail<TResult?> result = new();
 
-		bool requiredPropertyMissing = false;
 
 		foreach (var property in Properties)
 		{
-			if (property.IsRequired && property.IsMissing)
-			{
-				requiredPropertyMissing = true;
-				continue;
-			}
 			result.InheritFailure(property.ValidationResult);
 		}
 
-		if (!result.HasFailed && requiredPropertyMissing)
-		{
-			result.Succeeded(null);
-		}
-
-		if (!result.HasFailed && !requiredPropertyMissing)
+		if (!result.HasFailed)
 		{
 			result.Succeeded(creationMethod.Invoke());
 		}
@@ -41,27 +30,14 @@ public sealed class OptionalStructPropertyBuilder<TParameters, TResult> : Proper
 	{
 		CanFail<TResult?> result = new();
 
-		bool requiredPropertyMissing = false;
-
 		foreach (var property in Properties)
 		{
-			if (property.IsRequired && property.IsMissing)
-			{
-				requiredPropertyMissing = true;
-				continue;
-			}
 			result.InheritFailure(property.ValidationResult);
 		}
 
 		//Ensure the factory method wont get called if any errors occured to the parameters
 		if (result.HasFailed)
 		{
-			return new ValidatedOptionalStructProperty<TResult>(result);
-		}
-
-		if (requiredPropertyMissing)
-		{
-			result.Succeeded(null);
 			return new ValidatedOptionalStructProperty<TResult>(result);
 		}
 

--- a/CleanDomainValidation/Application/Structs/OptionalStructProperty.cs
+++ b/CleanDomainValidation/Application/Structs/OptionalStructProperty.cs
@@ -7,15 +7,11 @@ public sealed class OptionalStructProperty<TParameters, TProperty> : IValidatabl
 	where TParameters : notnull
 	where TProperty : struct
 {
-	public bool IsRequired => false;
-
-	public bool IsMissing { get; set; }
 	public TParameters Parameters { get; }
 	public CanFail ValidationResult { get; } = new();
 
 	internal OptionalStructProperty(TParameters parameters)
 	{
-		IsMissing = false;
 		Parameters = parameters;
 	}
 }

--- a/CleanDomainValidation/Application/Structs/RequiredStructProperty.cs
+++ b/CleanDomainValidation/Application/Structs/RequiredStructProperty.cs
@@ -6,15 +6,12 @@ public sealed class RequiredStructProperty<TParameters, TProperty> : IValidatabl
 	where TParameters : notnull
 	where TProperty : struct
 {
-	public bool IsRequired => true;
-	public bool IsMissing { get; set; }
 	public Error MissingError { get; }
 	public TParameters Parameters { get; }
 	public CanFail ValidationResult { get; } = new();
 
 	internal RequiredStructProperty(TParameters parameters, Error missingError)
 	{
-		IsMissing = false;
 		Parameters = parameters;
 		MissingError = missingError;
 	}

--- a/CleanDomainValidation/Application/Structs/StructProperty.cs
+++ b/CleanDomainValidation/Application/Structs/StructProperty.cs
@@ -8,9 +8,6 @@ public sealed class StructProperty<TParameters, TProperty> : IValidatablePropert
 {
 	private IValidatableProperty _property;
 	private TParameters _parameters;
-
-	public bool IsRequired => _property.IsRequired;
-	public bool IsMissing => _property.IsMissing;
 	public CanFail ValidationResult => _property.ValidationResult;
 
 	internal StructProperty(TParameters parameters)

--- a/CleanDomainValidation/Domain/CanFail.cs
+++ b/CleanDomainValidation/Domain/CanFail.cs
@@ -8,10 +8,8 @@ public sealed class CanFail : AbstractCanFail
 	/// <summary>
 	/// Creates successfull <see cref="CanFail"/> instance
 	/// </summary>
-	public static CanFail Success()
-	{
-		return new CanFail();
-	}
+
+	public static CanFail Success => new();
 
 	/// <summary>
 	/// Create <see cref="CanFail"/> instance containing the <paramref name="error"/>

--- a/CleanDomainValidation/Domain/CanFailOfT.cs
+++ b/CleanDomainValidation/Domain/CanFailOfT.cs
@@ -11,11 +11,6 @@ public sealed class CanFail<TResult> : AbstractCanFail, ICanFail<TResult>
 	private bool _valueSet = false;
 
 	/// <summary>
-	/// Error that occurs when the value is accessed but not set yet
-	/// </summary>
-	public static InvalidOperationException ValueNotSet => new ("The value of the result object has not been set yet");
-
-	/// <summary>
 	/// Access the value that should be returned normally
 	/// </summary>
 	/// <remarks>

--- a/CleanDomainValidation/Domain/Error.cs
+++ b/CleanDomainValidation/Domain/Error.cs
@@ -64,12 +64,4 @@ public sealed record Error
 	{
 		return new Error(ErrorType.Forbidden, code, message);
 	}
-
-	/// <summary>
-	/// Creates new Error of type Unexpected
-	/// </summary>
-	public static Error Unexpected(string code, string message)
-	{
-		return new Error(ErrorType.Unexpected, code, message);
-	}
 }

--- a/CleanDomainValidation/Domain/ErrorType.cs
+++ b/CleanDomainValidation/Domain/ErrorType.cs
@@ -24,9 +24,5 @@ public enum ErrorType
 	/// The user is not authorized to perform the action
 	/// </summary>
 	/// <example>A non admin user tries to change the permission of other users</example>
-	Forbidden,
-	/// <summary>
-	/// An unexpected error occured
-	/// </summary>
-	Unexpected
+	Forbidden
 }

--- a/Tests/ApplicationTests/Classes/OptionalClassTests.cs
+++ b/Tests/ApplicationTests/Classes/OptionalClassTests.cs
@@ -30,17 +30,6 @@ public record OStructValueObject(int Value)
 
 public class OptionalClassTests
 {
-    [Fact]
-    public void IsRequired_Should_BeFalse()
-    {
-        //Arrange
-        var value = "value";
-        var parameters = new OClassParameter(value);
-        var property = new OptionalClassProperty<OClassParameter, string>(parameters);
-
-        //Assert
-        property.IsRequired.Should().BeFalse();
-    }
 
     #region Direct Mapped
 
@@ -75,21 +64,6 @@ public class OptionalClassTests
     }
 
     [Fact]
-    public void DirectMap_IsMissingShouldBeFalse_WhenValueNotNull()
-    {
-        //Arrange
-        var value = "value";
-        var parameters = new OClassParameter(value);
-        var property = new OptionalClassProperty<OClassParameter, string>(parameters);
-
-        //Act
-        _ = property.Map(p => p.Value);
-
-        //Assert
-        property.IsMissing.Should().BeFalse();
-    }
-
-    [Fact]
     public void DirectMap_ShouldReturnNull_WhenValueNull()
     {
         //Arrange
@@ -115,20 +89,6 @@ public class OptionalClassTests
 
         //Assert
         property.ValidationResult.HasFailed.Should().BeFalse();
-    }
-
-    [Fact]
-    public void DirectMap_IsMissingShouldBeTrue_WhenValueNull()
-    {
-        //Arrange
-        var parameters = new OClassParameter(null);
-        var property = new OptionalClassProperty<OClassParameter, string>(parameters);
-
-        //Act
-        _ = property.Map(p => p.Value);
-
-        //Assert
-        property.IsMissing.Should().BeTrue();
     }
 
     #endregion
@@ -193,36 +153,6 @@ public class OptionalClassTests
 
         //Assert
         property.ValidationResult.HasFailed.Should().BeFalse();
-    }
-
-    [Fact]
-    public void FactoryMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-    {
-        //Arrange
-        var value = "value";
-        var parameters = new OClassParameter(value);
-        var property = new OptionalClassProperty<OClassParameter, OClassValueObject>(parameters);
-
-        //Act
-        _ = property.Map(p => p.Value, OClassValueObject.Create);
-
-        //Assert
-        property.IsMissing.Should().BeFalse();
-    }
-
-    [Fact]
-    public void FactoryMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-    {
-        //Arrange
-        var value = 1;
-        var parameters = new OStructParameter(value);
-        var property = new OptionalClassProperty<OStructParameter, OStructValueObject>(parameters);
-
-        //Act
-        _ = property.Map(p => p.Value, OStructValueObject.Create);
-
-        //Assert
-        property.IsMissing.Should().BeFalse();
     }
 
     [Fact]
@@ -345,34 +275,6 @@ public class OptionalClassTests
         property.ValidationResult.HasFailed.Should().BeFalse();
     }
 
-    [Fact]
-    public void FactoryMapClass_IsMissingShouldBeTrue_WhenValueNull()
-    {
-        //Arrange
-        var parameters = new OClassParameter(null);
-        var property = new OptionalClassProperty<OClassParameter, OClassValueObject>(parameters);
-
-        //Act
-        _ = property.Map(p => p.Value, OClassValueObject.Create);
-
-        //Assert
-        property.IsMissing.Should().BeTrue();
-    }
-
-    [Fact]
-    public void FactoryMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-    {
-        //Arrange
-        var parameters = new OStructParameter(null);
-        var property = new OptionalClassProperty<OStructParameter, OStructValueObject>(parameters);
-
-        //Act
-        _ = property.Map(p => p.Value, OStructValueObject.Create);
-
-        //Assert
-        property.IsMissing.Should().BeTrue();
-    }
-
     #endregion
 
     #region Constructor Mapped
@@ -438,36 +340,6 @@ public class OptionalClassTests
 	}
 
     [Fact]
-	public void ConstructorMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-    {
-		//Arrange
-		var value = "value";
-		var parameters = new OClassParameter(value);
-		var property = new OptionalClassProperty<OClassParameter, OClassValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new OClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-    [Fact]
-	public void ConstructorMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-    {
-		//Arrange
-		var value = 1;
-		var parameters = new OStructParameter(value);
-		var property = new OptionalClassProperty<OStructParameter, OStructValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new OStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-    [Fact]
     public void ConstructorMapClass_ShouldReturnNull_WhenValueNull()
     {
         //Arrange
@@ -521,34 +393,6 @@ public class OptionalClassTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-    [Fact]
-	public void ConstructorMapClass_IsMissingShouldBeTrue_WhenValueNull()
-    {
-		//Arrange
-		var parameters = new OClassParameter(null);
-		var property = new OptionalClassProperty<OClassParameter, OClassValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new OClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-    [Fact]
-	public void ConstructorMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-    {
-		//Arrange
-		var parameters = new OStructParameter(null);
-		var property = new OptionalClassProperty<OStructParameter, OStructValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new OStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -626,42 +470,6 @@ public class OptionalClassTests
 
         //Assert
         property.ValidationResult.HasFailed.Should().BeFalse();
-    }
-
-    [Fact]
-    public void ComplexMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-    {
-        //Arrange
-        var value = "value";
-        var parameters = new OClassParameter(value);
-        var property = new OptionalClassProperty<OClassParameter, OClassValueObject>(parameters);
-
-        //Act
-        _ = property.MapComplex(p => p.Value, builder =>
-            {
-                return new ValidatedOptionalClassProperty<OClassValueObject>(new OClassValueObject(value));
-            });
-
-        //Assert
-        property.IsMissing.Should().BeFalse();
-    }
-
-    [Fact]
-    public void ComplexMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-    {
-        //Arrange
-        var value = 1;
-        var parameters = new OStructParameter(value);
-        var property = new OptionalClassProperty<OStructParameter, OStructValueObject>(parameters);
-
-        //Act
-        _ = property.MapComplex(p => p.Value, builder =>
-        {
-            return new ValidatedOptionalClassProperty<OStructValueObject>(new OStructValueObject(value));
-        });
-
-        //Assert
-        property.IsMissing.Should().BeFalse();
     }
 
     [Fact]
@@ -804,40 +612,6 @@ public class OptionalClassTests
 
         //Assert
         property.ValidationResult.HasFailed.Should().BeFalse();
-    }
-
-    [Fact]
-    public void ComplexMapClass_IsMissingShouldBeTrue_WhenValueNull()
-    {
-        //Arrange
-        var parameters = new OClassParameter(null);
-        var property = new OptionalClassProperty<OClassParameter, OClassValueObject>(parameters);
-
-        //Act
-        _ = property.MapComplex(p => p.Value, builder =>
-        {
-            return new ValidatedOptionalClassProperty<OClassValueObject>((OClassValueObject?)null);
-        });
-
-        //Assert
-        property.IsMissing.Should().BeTrue();
-    }
-
-    [Fact]
-    public void ComplexMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-    {
-        //Arrange
-        var parameters = new OStructParameter(null);
-        var property = new OptionalClassProperty<OStructParameter, OStructValueObject>(parameters);
-
-        //Act
-        _ = property.MapComplex(p => p.Value, builder =>
-        {
-            return new ValidatedOptionalClassProperty<OStructValueObject>((OStructValueObject?)null);
-        });
-
-        //Assert
-        property.IsMissing.Should().BeTrue();
     }
 
     #endregion

--- a/Tests/ApplicationTests/Classes/RequiredClassTests.cs
+++ b/Tests/ApplicationTests/Classes/RequiredClassTests.cs
@@ -30,17 +30,6 @@ public record RStructValueObject(int Value)
 public class RequiredClassTests
 {
 	private static Error _missing => Error.Validation("Error.Missing", "The value is missing");
-	[Fact]
-	public void IsRequired_Should_BeTrue()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new RClassParameter(value);
-		var property = new RequiredClassProperty<RClassParameter, string>(parameters, _missing);
-
-		//Assert
-		property.IsRequired.Should().BeTrue();
-	}
 
 	#region Direct Mapped
 
@@ -75,21 +64,6 @@ public class RequiredClassTests
 	}
 
 	[Fact]
-	public void DirectMap_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new RClassParameter(value);
-		var property = new RequiredClassProperty<RClassParameter, string>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void DirectMap_ShouldReturnNull_WhenValueNull()
 	{
 		//Arrange
@@ -116,20 +90,6 @@ public class RequiredClassTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missing);
-	}
-
-	[Fact]
-	public void DirectMap_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RClassParameter(null);
-		var property = new RequiredClassProperty<RClassParameter, string>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -194,36 +154,6 @@ public class RequiredClassTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new RClassParameter(value);
-		var property = new RequiredClassProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, RClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new RStructParameter(value);
-		var property = new RequiredClassProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, RStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -348,34 +278,6 @@ public class RequiredClassTests
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missing);
 	}
 
-	[Fact]
-	public void FactoryMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RClassParameter(null);
-		var property = new RequiredClassProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, RClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void FactoryMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RStructParameter(null);
-		var property = new RequiredClassProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, RStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Constructor Mapped
@@ -441,36 +343,6 @@ public class RequiredClassTests
 	}
 
 	[Fact]
-	public void ConstructorMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new RClassParameter(value);
-		var property = new RequiredClassProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new RClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ConstructorMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new RStructParameter(value);
-		var property = new RequiredClassProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new RStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void ConstructorMapClass_ShouldReturnNull_WhenValueNull()
 	{
 		//Arrange
@@ -526,34 +398,6 @@ public class RequiredClassTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missing);
-	}
-
-	[Fact]
-	public void ConstructorMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RClassParameter(null);
-		var property = new RequiredClassProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new RClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ConstructorMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RStructParameter(null);
-		var property = new RequiredClassProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new RStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -631,42 +475,6 @@ public class RequiredClassTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new RClassParameter(value);
-		var property = new RequiredClassProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedRequiredProperty<RClassValueObject>(new RClassValueObject(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new RStructParameter(value);
-		var property = new RequiredClassProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedRequiredProperty<RStructValueObject>(new RStructValueObject(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -811,40 +619,6 @@ public class RequiredClassTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missing);
-	}
-
-	[Fact]
-	public void ComplexMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RClassParameter(null);
-		var property = new RequiredClassProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedRequiredProperty<RClassValueObject>(_missing);
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ComplexMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RStructParameter(null);
-		var property = new RequiredClassProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedRequiredProperty<RStructValueObject>(_missing);
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion

--- a/Tests/ApplicationTests/Enums/OptionalEnumTests.cs
+++ b/Tests/ApplicationTests/Enums/OptionalEnumTests.cs
@@ -24,18 +24,6 @@ public class OptionalEnumTests
 {
 	private static Error _invalidEnumError => Error.Validation("Enum.Invalid", "The enum is invalid");
 
-	[Fact]
-	public void IsRequired_Should_BeFalse()
-	{
-		//Arrange
-		var value = "One";
-		var parameters = new OStringParameter(value);
-		var property = new OptionalEnumProperty<OStringParameter, OTestEnum>(parameters);
-
-		//Assert
-		property.IsRequired.Should().BeFalse();
-	}
-
 	#region String to enum
 
 	[Fact]
@@ -66,21 +54,6 @@ public class OptionalEnumTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void Map_IsMissingShouldBeFalse_WhenStringNotNull()
-	{
-		//Arrange
-		var value = "One";
-		var parameters = new OStringParameter(value);
-		var property = new OptionalEnumProperty<OStringParameter, OTestEnum>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -127,20 +100,6 @@ public class OptionalEnumTests
 		property.ValidationResult.HasFailed.Should().BeFalse();
 	}
 
-	[Fact]
-	public void Map_IsMissingShouldBeTrue_WhenStringNull()
-	{
-		//Arrange
-		var parameters = new OStringParameter(null);
-		var property = new OptionalEnumProperty<OStringParameter, OTestEnum>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Int to enum
@@ -175,20 +134,6 @@ public class OptionalEnumTests
 		property.ValidationResult.HasFailed.Should().BeFalse();
 	}
 
-	[Fact]
-	public void Map_IsMissingShouldBeFalse_WhenIntNotNull()
-	{
-		//Arrange
-		var value = 0;
-		var parameters = new OIntParameter(value);
-		var property = new OptionalEnumProperty<OIntParameter, OTestEnum>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
 
 	[Fact]
 	public void Map_ShouldSetInvalidEnumError_WhenIntInvalid()
@@ -232,20 +177,6 @@ public class OptionalEnumTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void Map_IsMissingShouldBeTrue_WhenIntNull()
-	{
-		//Arrange
-		var parameters = new OIntParameter(null);
-		var property = new OptionalEnumProperty<OIntParameter, OTestEnum>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion

--- a/Tests/ApplicationTests/Enums/RequiredEnumTests.cs
+++ b/Tests/ApplicationTests/Enums/RequiredEnumTests.cs
@@ -24,18 +24,6 @@ public class RequiredEnumTests
 	private static Error _missingError => Error.Validation("Enum.Missing", "The enum is missing");
 	private static Error _invalidEnumError => Error.Validation("Enum.Invalid", "The enum is invalid");
 
-	[Fact]
-	public void IsRequired_Should_BeTrue()
-	{
-		//Arrange
-		var value = "One";
-		var parameters = new RStringParameter(value);
-		var property = new RequiredEnumProperty<RStringParameter, RTestEnum>(parameters, _missingError);
-
-		//Assert
-		property.IsRequired.Should().BeTrue();
-	}
-
 	#region String to enum
 
 	[Fact]
@@ -66,21 +54,6 @@ public class RequiredEnumTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void Map_IsMissingShouldBeFalse_WhenStringNotNull()
-	{
-		//Arrange
-		var value = "One";
-		var parameters = new RStringParameter(value);
-		var property = new RequiredEnumProperty<RStringParameter, RTestEnum>(parameters, _missingError);
-
-		//Act
-		var validatedProperty = property.Map(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -128,20 +101,6 @@ public class RequiredEnumTests
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missingError);
 	}
 
-	[Fact]
-	public void Map_IsMissingShouldBeTrue_WhenStringNull()
-	{
-		//Arrange
-		var parameters = new RStringParameter(null);
-		var property = new RequiredEnumProperty<RStringParameter, RTestEnum>(parameters, _missingError);
-
-		//Act
-		var validatedProperty = property.Map(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Int to enum
@@ -174,21 +133,6 @@ public class RequiredEnumTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void Map_IsMissingShouldBeFalse_WhenIntNotNull()
-	{
-		//Arrange
-		var value = 0;
-		var parameters = new RIntParameter(value);
-		var property = new RequiredEnumProperty<RIntParameter, RTestEnum>(parameters, _missingError);
-
-		//Act
-		var validatedProperty = property.Map(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -234,20 +178,6 @@ public class RequiredEnumTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missingError);
-	}
-
-	[Fact]
-	public void Map_IsMissingShouldBeTrue_WhenIntNull()
-	{
-		//Arrange
-		var parameters = new RIntParameter(null);
-		var property = new RequiredEnumProperty<RIntParameter, RTestEnum>(parameters, _missingError);
-
-		//Act
-		var validatedProperty = property.Map(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion

--- a/Tests/ApplicationTests/Lists/OptionalListTests.cs
+++ b/Tests/ApplicationTests/Lists/OptionalListTests.cs
@@ -43,18 +43,6 @@ public class OptionalListTests
 {
 	private static Error _invalidEnumError => Error.Validation("Enum.Invalid", "The enum is invalid");
 
-	[Fact]
-	public void IsRequired_Should_BeFalse()
-	{
-		//Arrange
-		List<string> value = ["value1"];
-		var parameters = new OClassListParameter(value);
-		var property = new OptionalListProperty<OClassListParameter, string>(parameters);
-
-		//Assert
-		property.IsRequired.Should().BeFalse();
-	}
-
 	#region Direct Mapped
 
 	[Fact]
@@ -118,36 +106,6 @@ public class OptionalListTests
 	}
 
 	[Fact]
-	public void DirectMapEachClass_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["value1", "value2"];
-		var parameters = new OClassListParameter(value);
-		var property = new OptionalListProperty<OClassListParameter, string>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void DirectMapEachStruct_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [1, 2];
-		var parameters = new OStructListParameter(value);
-		var property = new OptionalListProperty<OStructListParameter, int>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void DirectMapEachClass_ShouldReturnNull_WhenParameterListIsNull()
 	{
 		//Arrange
@@ -201,34 +159,6 @@ public class OptionalListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void DirectMapEachClass_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new OClassListParameter(null);
-		var property = new OptionalListProperty<OClassListParameter, string>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void DirectMapEachStruct_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new OStructListParameter(null);
-		var property = new OptionalListProperty<OStructListParameter, int>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -293,36 +223,6 @@ public class OptionalListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapEachClass_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["value1", "value2"];
-		var parameters = new OClassListParameter(value);
-		var property = new OptionalListProperty<OClassListParameter, OClassValueObject>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, OClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapEachStruct_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [1, 2];
-		var parameters = new OStructListParameter(value);
-		var property = new OptionalListProperty<OStructListParameter, OStructValueObject>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, OStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -413,34 +313,6 @@ public class OptionalListTests
 		property.ValidationResult.HasFailed.Should().BeFalse();
 	}
 
-	[Fact]
-	public void FactoryMapEachClass_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new OClassListParameter(null);
-		var property = new OptionalListProperty<OClassListParameter, OClassValueObject>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, OClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void FactoryMapEachStruct_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new OStructListParameter(null);
-		var property = new OptionalListProperty<OStructListParameter, OStructValueObject>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, OStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Constructor Mapped
@@ -506,36 +378,6 @@ public class OptionalListTests
 	}
 
 	[Fact]
-	public void ConstructorMapEachClass_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["value1", "value2"];
-		var parameters = new OClassListParameter(value);
-		var property = new OptionalListProperty<OClassListParameter, OClassValueObject>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, v => new OClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ConstructorMapEachStruct_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [1, 2];
-		var parameters = new OStructListParameter(value);
-		var property = new OptionalListProperty<OStructListParameter, OStructValueObject>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, v => new OStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void ConstructorMapEachClass_ShouldReturnNull_WhenParameterListIsNull()
 	{
 		//Arrange
@@ -589,34 +431,6 @@ public class OptionalListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ConstructorMapEachClass_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new OClassListParameter(null);
-		var property = new OptionalListProperty<OClassListParameter, OClassValueObject>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, v => new OClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ConstructorMapEachStruct_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new OStructListParameter(null);
-		var property = new OptionalListProperty<OStructListParameter, OStructValueObject>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, v => new OStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -705,48 +519,6 @@ public class OptionalListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapEachClass_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["value1", "value2"];
-		var parameters = new OClassListParameter(value);
-		var property = new OptionalListProperty<OClassListParameter, OClassValueObject>(parameters);
-
-		//Act
-		var result = property.MapEachComplex(p => p.Value, builder =>
-		{
-			var value = builder.ClassProperty(p => p.Value)
-				.Required(Error.Validation("Error.Missing", "missing error"))
-				.Map(r => r);
-			return builder.Build(() => OClassValueObject.Create(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapEachStruct_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [1, 2];
-		var parameters = new OStructListParameter(value);
-		var property = new OptionalListProperty<OStructListParameter, OStructValueObject>(parameters);
-
-		//Act
-		var result = property.MapEachComplex(p => p.Value, builder =>
-		{
-			var value = builder.StructProperty(p => p.Value)
-				.Required(Error.Validation("Error.Missing", "missing error"))
-				.Map(r => r);
-			return builder.Build(() => OStructValueObject.Create(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -873,46 +645,6 @@ public class OptionalListTests
 		property.ValidationResult.HasFailed.Should().BeFalse();
 	}
 
-	[Fact]
-	public void ComplexMapEachClass_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new OClassListParameter(null);
-		var property = new OptionalListProperty<OClassListParameter, OClassValueObject>(parameters);
-
-		//Act
-		var result = property.MapEachComplex(p => p.Value, builder =>
-		{
-			var value = builder.ClassProperty(p => p.Value)
-				.Required(Error.Validation("Error.Missing", "missing error"))
-				.Map(r => r);
-			return builder.Build(() => OClassValueObject.Create(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ComplexMapEachStruct_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new OStructListParameter(null);
-		var property = new OptionalListProperty<OStructListParameter, OStructValueObject>(parameters);
-
-		//Act
-		var result = property.MapEachComplex(p => p.Value, builder =>
-		{
-			var value = builder.StructProperty(p => p.Value)
-				.Required(Error.Validation("Error.Missing", "missing error"))
-				.Map(r => r);
-			return builder.Build(() => OStructValueObject.Create(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Enums
@@ -975,36 +707,6 @@ public class OptionalListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void MapEachEnum_IsMissingShouldBeFalse_WhenStringListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["One", "Two"];
-		var parameters = new OClassListParameter(value);
-		var property = new OptionalListProperty<OClassListParameter, OTestEnum>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void MapEachEnum_IsMissingShouldBeFalse_WhenIntListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [0, 1];
-		var parameters = new OStructListParameter(value);
-		var property = new OptionalListProperty<OStructListParameter, OTestEnum>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -1093,34 +795,6 @@ public class OptionalListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void MapEachEnum_IsMissingShouldBeTrue_WhenStringListIsNull()
-	{
-		//Arrange
-		var parameters = new OClassListParameter(null);
-		var property = new OptionalListProperty<OClassListParameter, OTestEnum>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void MapEachEnum_IsMissingShouldBeTrue_WhenIntListIsNull()
-	{
-		//Arrange
-		var parameters = new OStructListParameter(null);
-		var property = new OptionalListProperty<OStructListParameter, OTestEnum>(parameters);
-
-		//Act
-		var result = property.MapEach(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion

--- a/Tests/ApplicationTests/Lists/RequiredListTests.cs
+++ b/Tests/ApplicationTests/Lists/RequiredListTests.cs
@@ -45,18 +45,6 @@ public class RequiredListTests
 	private static Error _missingError = Error.Validation("Error.Missing", "The value is missing");
 	private static Error _invalidEnumError => Error.Validation("Enum.Invalid", "The enum is invalid");
 
-	[Fact]
-	public void IsRequired_Should_BeTrue()
-	{
-		//Arrange
-		List<string> value = ["value1"];
-		var parameters = new OClassListParameter(value);
-		var property = new RequiredListProperty<OClassListParameter, string>(parameters, _missingError);
-
-		//Assert
-		property.IsRequired.Should().BeTrue();
-	}
-
 	#region Direct Mapped
 
 	[Fact]
@@ -120,36 +108,6 @@ public class RequiredListTests
 	}
 
 	[Fact]
-	public void DirectMapEachClass_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["value1", "value2"];
-		var parameters = new RClassListParameter(value);
-		var property = new RequiredListProperty<RClassListParameter, string>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void DirectMapEachStruct_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [1, 2];
-		var parameters = new RStructListParameter(value);
-		var property = new RequiredListProperty<RStructListParameter, int>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void DirectMapEachClass_ShouldReturnNull_WhenParameterListIsNull()
 	{
 		//Arrange
@@ -205,34 +163,6 @@ public class RequiredListTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missingError);
-	}
-
-	[Fact]
-	public void DirectMapEachClass_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new RClassListParameter(null);
-		var property = new RequiredListProperty<RClassListParameter, string>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void DirectMapEachStruct_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new RStructListParameter(null);
-		var property = new RequiredListProperty<RStructListParameter, int>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -297,36 +227,6 @@ public class RequiredListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapEachClass_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["value1", "value2"];
-		var parameters = new RClassListParameter(value);
-		var property = new RequiredListProperty<RClassListParameter, RClassValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, RClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapEachStruct_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [1, 2];
-		var parameters = new RStructListParameter(value);
-		var property = new RequiredListProperty<RStructListParameter, RStructValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, RStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -419,34 +319,6 @@ public class RequiredListTests
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missingError);
 	}
 
-	[Fact]
-	public void FactoryMapEachClass_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new RClassListParameter(null);
-		var property = new RequiredListProperty<RClassListParameter, RClassValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, RClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void FactoryMapEachStruct_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new RStructListParameter(null);
-		var property = new RequiredListProperty<RStructListParameter, RStructValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, RStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Constructor Mapped
@@ -512,36 +384,6 @@ public class RequiredListTests
 	}
 
 	[Fact]
-	public void ConstructorMapEachClass_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["value1", "value2"];
-		var parameters = new RClassListParameter(value);
-		var property = new RequiredListProperty<RClassListParameter, RClassValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, v => new RClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ConstructorMapEachStruct_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [1, 2];
-		var parameters = new RStructListParameter(value);
-		var property = new RequiredListProperty<RStructListParameter, RStructValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, v => new RStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void ConstructorMapEachClass_ShouldReturnNull_WhenParameterListIsNull()
 	{
 		//Arrange
@@ -598,35 +440,6 @@ public class RequiredListTests
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missingError);
 	}
-
-	[Fact]
-	public void ConstructorMapEachClass_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new RClassListParameter(null);
-		var property = new RequiredListProperty<RClassListParameter, RClassValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, v => new RClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ConstructorMapEachStruct_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new RStructListParameter(null);
-		var property = new RequiredListProperty<RStructListParameter, RStructValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, v => new RStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Compex Mapped
@@ -713,48 +526,6 @@ public class RequiredListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapEachClass_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["value1", "value2"];
-		var parameters = new RClassListParameter(value);
-		var property = new RequiredListProperty<RClassListParameter, RClassValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEachComplex(p => p.Value, builder =>
-		{
-			var value = builder.ClassProperty(p => p.Value)
-				.Required(Error.Validation("Error.Missing", "missing error"))
-				.Map(r => r);
-			return builder.Build(() => RClassValueObject.Create(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapEachStruct_IsMissingShouldBeFalse_WhenParameterListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [1, 2];
-		var parameters = new RStructListParameter(value);
-		var property = new RequiredListProperty<RStructListParameter, RStructValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEachComplex(p => p.Value, builder =>
-		{
-			var value = builder.StructProperty(p => p.Value)
-				.Required(Error.Validation("Error.Missing", "missing error"))
-				.Map(r => r);
-			return builder.Build(() => RStructValueObject.Create(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -883,46 +654,6 @@ public class RequiredListTests
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missingError);
 	}
 
-	[Fact]
-	public void ComplexMapEachClass_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new RClassListParameter(null);
-		var property = new RequiredListProperty<RClassListParameter, RClassValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEachComplex(p => p.Value, builder =>
-		{
-			var value = builder.ClassProperty(p => p.Value)
-				.Required(Error.Validation("Error.Missing", "missing error"))
-				.Map(r => r);
-			return builder.Build(() => RClassValueObject.Create(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ComplexMapEachStruct_IsMissingShouldBeTrue_WhenParameterListIsNull()
-	{
-		//Arrange
-		var parameters = new RStructListParameter(null);
-		var property = new RequiredListProperty<RStructListParameter, RStructValueObject>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEachComplex(p => p.Value, builder =>
-		{
-			var value = builder.StructProperty(p => p.Value)
-				.Required(Error.Validation("Error.Missing", "missing error"))
-				.Map(r => r);
-			return builder.Build(() => RStructValueObject.Create(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Enum
@@ -985,36 +716,6 @@ public class RequiredListTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void MapEachEnum_IsMissingShouldBeFalse_WhenStringListIsNotNull()
-	{
-		//Arrange
-		List<string> value = ["One", "Two"];
-		var parameters = new RStringListParameter(value);
-		var property = new RequiredListProperty<RStringListParameter, RTestEnum>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void MapEachEnum_IsMissingShouldBeFalse_WhenIntListIsNotNull()
-	{
-		//Arrange
-		List<int> value = [0, 1];
-		var parameters = new RIntListParameter(value);
-		var property = new RequiredListProperty<RIntListParameter, RTestEnum>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -1105,34 +806,6 @@ public class RequiredListTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missingError);
-	}
-
-	[Fact]
-	public void MapEachEnum_IsMissingShouldBeTrue_WhenStringListIsNull()
-	{
-		//Arrange
-		var parameters = new RStringListParameter(null);
-		var property = new RequiredListProperty<RStringListParameter, RTestEnum>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void MapEachEnum_IsMissingShouldBeTrue_WhenIntListIsNull()
-	{
-		//Arrange
-		var parameters = new RIntListParameter(null);
-		var property = new RequiredListProperty<RIntListParameter, RTestEnum>(parameters, _missingError);
-
-		//Act
-		var result = property.MapEach(p => p.Value, _invalidEnumError);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion

--- a/Tests/ApplicationTests/OptionalClassPropertyBuilderTests.cs
+++ b/Tests/ApplicationTests/OptionalClassPropertyBuilderTests.cs
@@ -1,0 +1,146 @@
+﻿using CleanDomainValidation.Application;
+using CleanDomainValidation.Application.Extensions;
+using CleanDomainValidation.Domain;
+using FluentAssertions;
+
+namespace Tests.ApplicationTests;
+
+public record OCPParameter(string? Value) : IParameters;
+
+public record OCPResult(string? Value)
+{
+    public static CanFail<OCPResult> Create(string value)
+    {
+        if (value == "error")
+        {
+            return RequiredPropertyBuilderTests.ExampleError;
+        }
+
+        return new OCPResult(value);
+    }
+}
+public class OptionalClassPropertyBuilderTests
+{
+    public static Error ExampleError => Error.Validation("Validation.Error", "An error occured");
+
+    private static Error _missingError => Error.Validation("Error.Missing", "Value is missing");
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithoutErrors_WhenNoErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OCPParameter("value");
+        var builder = new OptionalClassPropertyBuilder<OCPParameter, OCPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new OCPResult(value)).Build();
+
+        //Assert
+        result.HasFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithResult_WhenNoPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OCPParameter("value");
+        var builder = new OptionalClassPropertyBuilder<OCPParameter, OCPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new OCPResult(value)).Build();
+
+        //Assert
+        result.Value.Should().Be(new OCPResult("value"));
+    }
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OCPParameter(null);
+        var builder = new OptionalClassPropertyBuilder<OCPParameter, OCPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new OCPResult(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(_missingError);
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithoutErrors_WhenNoErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OCPParameter("value");
+        var builder = new OptionalClassPropertyBuilder<OCPParameter, OCPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => OCPResult.Create(value)).Build();
+
+        //Assert
+        result.HasFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithResult_WhenNoPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OCPParameter("value");
+        var builder = new OptionalClassPropertyBuilder<OCPParameter, OCPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => OCPResult.Create(value)).Build();
+
+        //Assert
+        result.Value.Should().Be(new OCPResult("value"));
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OCPParameter(null);
+        var builder = new OptionalClassPropertyBuilder<OCPParameter, OCPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => OCPResult.Create(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(_missingError);
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenBuildErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OCPParameter("error");
+        var builder = new OptionalClassPropertyBuilder<OCPParameter, OCPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => OCPResult.Create(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(ExampleError);
+    }
+}

--- a/Tests/ApplicationTests/OptionalStructPropertyBuilderTests.cs
+++ b/Tests/ApplicationTests/OptionalStructPropertyBuilderTests.cs
@@ -1,0 +1,147 @@
+﻿using CleanDomainValidation.Application;
+using CleanDomainValidation.Application.Extensions;
+using CleanDomainValidation.Domain;
+using FluentAssertions;
+
+namespace Tests.ApplicationTests;
+
+public record OSPParameter(string? Value) : IParameters;
+
+public record struct OSPResult(string? Value)
+{
+    public static CanFail<OSPResult> Create(string value)
+    {
+        if (value == "error")
+        {
+            return RequiredPropertyBuilderTests.ExampleError;
+        }
+
+        return new OSPResult(value);
+    }
+}
+
+public class OptionalStructPropertyBuilderTests
+{
+    public static Error ExampleError => Error.Validation("Validation.Error", "An error occured");
+
+    private static Error _missingError => Error.Validation("Error.Missing", "Value is missing");
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithoutErrors_WhenNoErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OSPParameter("value");
+        var builder = new OptionalStructPropertyBuilder<OSPParameter, OSPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new OSPResult(value)).Build();
+
+        //Assert
+        result.HasFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithResult_WhenNoPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OSPParameter("value");
+        var builder = new OptionalStructPropertyBuilder<OSPParameter, OSPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new OSPResult(value)).Build();
+
+        //Assert
+        result.Value.Should().Be(new OSPResult("value"));
+    }
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OSPParameter(null);
+        var builder = new OptionalStructPropertyBuilder<OSPParameter, OSPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new OSPResult(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(_missingError);
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithoutErrors_WhenNoErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OSPParameter("value");
+        var builder = new OptionalStructPropertyBuilder<OSPParameter, OSPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => OSPResult.Create(value)).Build();
+
+        //Assert
+        result.HasFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithResult_WhenNoPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OSPParameter("value");
+        var builder = new OptionalStructPropertyBuilder<OSPParameter, OSPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => OSPResult.Create(value)).Build();
+
+        //Assert
+        result.Value.Should().Be(new OSPResult("value"));
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OSPParameter(null);
+        var builder = new OptionalStructPropertyBuilder<OSPParameter, OSPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => OSPResult.Create(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(_missingError);
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenBuildErrorsOccured()
+    {
+        //Arrange
+        var parameters = new OSPParameter("error");
+        var builder = new OptionalStructPropertyBuilder<OSPParameter, OSPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => OSPResult.Create(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(ExampleError);
+    }
+}

--- a/Tests/ApplicationTests/PropertyBuilderTests.cs
+++ b/Tests/ApplicationTests/PropertyBuilderTests.cs
@@ -1,0 +1,204 @@
+﻿using CleanDomainValidation.Application;
+using CleanDomainValidation.Application.Classes;
+using CleanDomainValidation.Application.Enums;
+using CleanDomainValidation.Application.Lists;
+using CleanDomainValidation.Application.Structs;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestPlatform.Common.Utilities;
+
+namespace Tests.ApplicationTests;
+
+public record Parameters() : IParameters;
+public record Result(
+    string RequiredClassProperty,
+    string? OptionalClassProperty,
+    int RequiredStructProperty,
+    int? OptionalStructProperty,
+    TestEnum RequiredEnumProperty,
+    TestEnum? OptionalEnumProperty,
+    List<int> RequiredListProperty,
+    List<int>? OptionalListProperty);
+
+public enum TestEnum
+{
+    One
+}
+
+public class TestablePropertyBuilder : PropertyBuilder<Parameters, Result>
+{
+    public new IReadOnlyList<IValidatableProperty> Properties => base.Properties;
+    public TestablePropertyBuilder(Parameters parameters) : base(parameters)
+    {
+    }
+}
+
+public class PropertyBuilderTests
+{
+    [Fact]
+    public void ClassProperty_ShouldReturnClassProperty_OnClassProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.ClassProperty(x => x.RequiredClassProperty);
+
+        //Assert
+        builder.Should().BeOfType<ClassProperty<Parameters, string>>();
+    }
+
+    [Fact]
+    public void ClassProperty_ShouldAddPropertyToList_OnClassProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.ClassProperty(x => x.RequiredClassProperty);
+
+        //Assert
+        propertyBuilder.Properties.Should().Contain(builder);
+    }
+
+    [Fact]
+    public void StructProperty_ShouldReturnStructProperty_OnRequiredStructProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.StructProperty(x => x.RequiredStructProperty);
+
+        //Assert
+        builder.Should().BeOfType<StructProperty<Parameters, int>>();
+    }
+
+    [Fact]
+    public void StructProperty_ShouldAddPropertyToList_OnRequiredStructProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.StructProperty(x => x.RequiredStructProperty);
+
+        //Assert
+        propertyBuilder.Properties.Should().Contain(builder);
+    }
+
+    [Fact]
+    public void StructProperty_ShouldReturnStructProperty_OnOptionalStructProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.StructProperty(x => x.OptionalStructProperty);
+
+        //Assert
+        builder.Should().BeOfType<StructProperty<Parameters, int>>();
+    }
+
+    [Fact]
+    public void StructProperty_ShouldAddPropertyToList_OnOptionalStructProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.StructProperty(x => x.OptionalStructProperty);
+
+        //Assert
+        propertyBuilder.Properties.Should().Contain(builder);
+    }
+
+    [Fact]
+    public void EnumProperty_ShouldReturnEnumProperty_OnRequiredEnumProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.EnumProperty(x => x.RequiredEnumProperty);
+
+        //Assert
+        builder.Should().BeOfType<EnumProperty<Parameters, TestEnum>>();
+    }
+
+    [Fact]
+    public void EnumProperty_ShouldAddPropertyToList_OnRequiredEnumProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.EnumProperty(x => x.RequiredEnumProperty);
+
+        //Assert
+        propertyBuilder.Properties.Should().Contain(builder);
+    }
+
+    [Fact]
+    public void EnumProperty_ShouldReturnEnumProperty_OnOptionalEnumProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.EnumProperty(x => x.OptionalEnumProperty);
+
+        //Assert
+        builder.Should().BeOfType<EnumProperty<Parameters, TestEnum>>();
+    }
+
+    [Fact]
+    public void EnumProperty_ShouldAddPropertyToList_OnOptionalEnumProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.EnumProperty(x => x.OptionalEnumProperty);
+
+        //Assert
+        propertyBuilder.Properties.Should().Contain(builder);
+    }
+
+    [Fact]
+    public void ListProperty_ShouldReturnListProperty_OnRequiredListProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.ListProperty(x => x.RequiredListProperty);
+
+        //Assert
+        builder.Should().BeOfType<ListProperty<Parameters, int>>();
+    }
+
+    [Fact]
+    public void ListProperty_ShouldAddPropertyToList_OnRequiredListProperty()
+    {
+        //Arrange
+        var parameters = new Parameters();
+        var propertyBuilder = new TestablePropertyBuilder(parameters);
+
+        //Act
+        var builder = propertyBuilder.ListProperty(x => x.RequiredListProperty);
+
+        //Assert
+        propertyBuilder.Properties.Should().Contain(builder);
+    }
+}

--- a/Tests/ApplicationTests/RequiredPropertyBuilderTests.cs
+++ b/Tests/ApplicationTests/RequiredPropertyBuilderTests.cs
@@ -1,0 +1,148 @@
+﻿using CleanDomainValidation.Application;
+using CleanDomainValidation.Application.Extensions;
+using CleanDomainValidation.Domain;
+using FluentAssertions;
+using System.Xml.Schema;
+
+namespace Tests.ApplicationTests;
+
+public record RPParameter(string? Value) : IParameters;
+
+public record RPResult(string? Value)
+{
+    public static CanFail<RPResult> Create(string value)
+    {
+        if(value == "error")
+        {
+            return RequiredPropertyBuilderTests.ExampleError;
+        }
+
+        return new RPResult(value);
+    }
+}
+
+public class RequiredPropertyBuilderTests
+{
+    public static Error ExampleError => Error.Validation("Validation.Error", "An error occured");
+
+    private static Error _missingError => Error.Validation("Error.Missing", "Value is missing");
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithoutErrors_WhenNoErrorsOccured()
+    {
+        //Arrange
+        var parameters = new RPParameter("value");
+        var builder = new RequiredPropertyBuilder<RPParameter, RPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new RPResult(value)).Build();
+
+        //Assert
+        result.HasFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithResult_WhenNoPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new RPParameter("value");
+        var builder = new RequiredPropertyBuilder<RPParameter, RPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new RPResult(value)).Build();
+
+        //Assert
+        result.Value.Should().Be(new RPResult("value"));
+    }
+
+    [Fact]
+    public void MethodBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new RPParameter(null);
+        var builder = new RequiredPropertyBuilder<RPParameter, RPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => new RPResult(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(_missingError);
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithoutErrors_WhenNoErrorsOccured()
+    {
+        //Arrange
+        var parameters = new RPParameter("value");
+        var builder = new RequiredPropertyBuilder<RPParameter, RPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => RPResult.Create(value)).Build();
+
+        //Assert
+        result.HasFailed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithResult_WhenNoPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new RPParameter("value");
+        var builder = new RequiredPropertyBuilder<RPParameter, RPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => RPResult.Create(value)).Build();
+
+        //Assert
+        result.Value.Should().Be(new RPResult("value"));
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenPropertyErrorsOccured()
+    {
+        //Arrange
+        var parameters = new RPParameter(null);
+        var builder = new RequiredPropertyBuilder<RPParameter, RPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => RPResult.Create(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(_missingError);
+    }
+
+    [Fact]
+    public void FactoryBuild_ShouldReturnValidatedRequiredPropertyWithErrors_WhenBuildErrorsOccured()
+    {
+        //Arrange
+        var parameters = new RPParameter("error");
+        var builder = new RequiredPropertyBuilder<RPParameter, RPResult>(parameters);
+        var value = builder.ClassProperty(x => x.Value)
+            .Required(_missingError)
+            .Map(x => x.Value);
+
+        //Act
+        var result = builder.Build(() => RPResult.Create(value)).Build();
+
+        //Assert
+        result.Errors.Should().Contain(ExampleError);
+    }
+}

--- a/Tests/ApplicationTests/Structs/OptionalStructTests.cs
+++ b/Tests/ApplicationTests/Structs/OptionalStructTests.cs
@@ -30,17 +30,6 @@ public record struct OStructValueObject(int Value)
 
 public class OptionalStructTests
 {
-	[Fact]
-	public void IsRequired_Should_BeFalse()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new OStructParameter(value);
-		var property = new OptionalStructProperty<OStructParameter, int>(parameters);
-
-		//Assert
-		property.IsRequired.Should().BeFalse();
-	}
 	#region Direct Mapped
 
 	[Fact]
@@ -74,21 +63,6 @@ public class OptionalStructTests
 	}
 
 	[Fact]
-	public void DirectMap_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new OStructParameter(value);
-		var property = new OptionalStructProperty<OStructParameter, int>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void DirectMap_ShouldReturnNull_WhenValueNull()
 	{
 		//Arrange
@@ -114,20 +88,6 @@ public class OptionalStructTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void DirectMap_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new OStructParameter(null);
-		var property = new OptionalStructProperty<OStructParameter, int>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -192,36 +152,6 @@ public class OptionalStructTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new OClassParameter(value);
-		var property = new OptionalStructProperty<OClassParameter, OClassValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, OClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new OStructParameter(value);
-		var property = new OptionalStructProperty<OStructParameter, OStructValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, OStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -344,34 +274,6 @@ public class OptionalStructTests
 		property.ValidationResult.HasFailed.Should().BeFalse();
 	}
 
-	[Fact]
-	public void FactoryMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new OClassParameter(null);
-		var property = new OptionalStructProperty<OClassParameter, OClassValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, OClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void FactoryMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new OStructParameter(null);
-		var property = new OptionalStructProperty<OStructParameter, OStructValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, OStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Constructor Mapped
@@ -437,36 +339,6 @@ public class OptionalStructTests
 	}
 
 	[Fact]
-	public void ConstructorMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new OClassParameter(value);
-		var property = new OptionalStructProperty<OClassParameter, OClassValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new OClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ConstructorMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new OStructParameter(value);
-		var property = new OptionalStructProperty<OStructParameter, OStructValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new OStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void ConstructorMapClass_ShouldReturnNull_WhenValueNull()
 	{
 		//Arrange
@@ -520,34 +392,6 @@ public class OptionalStructTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ConstructorMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new OClassParameter(null);
-		var property = new OptionalStructProperty<OClassParameter, OClassValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new OClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ConstructorMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new OStructParameter(null);
-		var property = new OptionalStructProperty<OStructParameter, OStructValueObject>(parameters);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new OStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -625,42 +469,6 @@ public class OptionalStructTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new OClassParameter(value);
-		var property = new OptionalStructProperty<OClassParameter, OClassValueObject>(parameters);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedOptionalStructProperty<OClassValueObject>(new OClassValueObject(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new OStructParameter(value);
-		var property = new OptionalStructProperty<OStructParameter, OStructValueObject>(parameters);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedOptionalStructProperty<OStructValueObject>(new OStructValueObject(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -803,40 +611,6 @@ public class OptionalStructTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new OClassParameter(null);
-		var property = new OptionalStructProperty<OClassParameter, OClassValueObject>(parameters);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedOptionalStructProperty<OClassValueObject>((OClassValueObject?)null);
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ComplexMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new OStructParameter(null);
-		var property = new OptionalStructProperty<OStructParameter, OStructValueObject>(parameters);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedOptionalStructProperty<OStructValueObject>((OStructValueObject?)null);
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion

--- a/Tests/ApplicationTests/Structs/RequiredStructTests.cs
+++ b/Tests/ApplicationTests/Structs/RequiredStructTests.cs
@@ -31,17 +31,6 @@ public record struct RStructValueObject(int Value)
 public class RequiredStructTests
 {
 	private static Error _missing => Error.Validation("Error.Missing", "The value is missing");
-	[Fact]
-	public void IsRequired_Should_BeTrue()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new RStructParameter(value);
-		var property = new RequiredStructProperty<RStructParameter, int>(parameters, _missing);
-
-		//Assert
-		property.IsRequired.Should().BeTrue();
-	}
 
 	#region Direct Mapped
 
@@ -76,21 +65,6 @@ public class RequiredStructTests
 	}
 
 	[Fact]
-	public void DirectMap_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new RStructParameter(value);
-		var property = new RequiredStructProperty<RStructParameter, int>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void DirectMap_ShouldReturnDefault_WhenValueNull()
 	{
 		//Arrange
@@ -117,20 +91,6 @@ public class RequiredStructTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missing);
-	}
-
-	[Fact]
-	public void DirectMap_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RStructParameter(null);
-		var property = new RequiredStructProperty<RStructParameter, int>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion
@@ -195,36 +155,6 @@ public class RequiredStructTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new RClassParameter(value);
-		var property = new RequiredStructProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, RClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void FactoryMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new RStructParameter(value);
-		var property = new RequiredStructProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, RStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -349,34 +279,6 @@ public class RequiredStructTests
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missing);
 	}
 
-	[Fact]
-	public void FactoryMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RClassParameter(null);
-		var property = new RequiredStructProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, RClassValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void FactoryMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RStructParameter(null);
-		var property = new RequiredStructProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, RStructValueObject.Create);
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
 	#endregion
 
 	#region Constructor Mapped
@@ -442,36 +344,6 @@ public class RequiredStructTests
 	}
 
 	[Fact]
-	public void ConstructorMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new RClassParameter(value);
-		var property = new RequiredStructProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new RClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ConstructorMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new RStructParameter(value);
-		var property = new RequiredStructProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new RStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
 	public void ConstructorMapClass_ShouldReturnDefault_WhenValueNull()
 	{
 		//Arrange
@@ -527,34 +399,6 @@ public class RequiredStructTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missing);
-	}
-
-	[Fact]
-	public void ConstructorMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RClassParameter(null);
-		var property = new RequiredStructProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new RClassValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ConstructorMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RStructParameter(null);
-		var property = new RequiredStructProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.Map(p => p.Value, v => new RStructValueObject(v));
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 
@@ -633,42 +477,6 @@ public class RequiredStructTests
 
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapClass_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = "value";
-		var parameters = new RClassParameter(value);
-		var property = new RequiredStructProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedRequiredProperty<RClassValueObject>(new RClassValueObject(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
-	}
-
-	[Fact]
-	public void ComplexMapStruct_IsMissingShouldBeFalse_WhenValueNotNull()
-	{
-		//Arrange
-		var value = 1;
-		var parameters = new RStructParameter(value);
-		var property = new RequiredStructProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedRequiredProperty<RStructValueObject>(new RStructValueObject(value));
-		});
-
-		//Assert
-		property.IsMissing.Should().BeFalse();
 	}
 
 	[Fact]
@@ -813,40 +621,6 @@ public class RequiredStructTests
 		//Assert
 		property.ValidationResult.HasFailed.Should().BeTrue();
 		property.ValidationResult.Errors.Should().ContainSingle().Which.Should().Be(_missing);
-	}
-
-	[Fact]
-	public void ComplexMapClass_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RClassParameter(null);
-		var property = new RequiredStructProperty<RClassParameter, RClassValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedRequiredProperty<RClassValueObject>(_missing);
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
-	}
-
-	[Fact]
-	public void ComplexMapStruct_IsMissingShouldBeTrue_WhenValueNull()
-	{
-		//Arrange
-		var parameters = new RStructParameter(null);
-		var property = new RequiredStructProperty<RStructParameter, RStructValueObject>(parameters, _missing);
-
-		//Act
-		_ = property.MapComplex(p => p.Value, builder =>
-		{
-			return new ValidatedRequiredProperty<RStructValueObject>(_missing);
-		});
-
-		//Assert
-		property.IsMissing.Should().BeTrue();
 	}
 
 	#endregion

--- a/Tests/ApplicationTests/ValidatedOptionalClassPropertyTests.cs
+++ b/Tests/ApplicationTests/ValidatedOptionalClassPropertyTests.cs
@@ -1,0 +1,22 @@
+﻿using CleanDomainValidation.Application;
+using CleanDomainValidation.Domain;
+using FluentAssertions;
+
+namespace Tests.ApplicationTests;
+
+public class ValidatedOptionalClassTests
+{
+    [Fact]
+    public void Build_ShouldReturnResultFromConstructor()
+    {
+        //Arrange
+        var result = new CanFail<string?>();
+        var property = new ValidatedOptionalClassProperty<string>(result);
+
+        //Act
+        var returnResult = property.Build();
+
+        //Assert
+        returnResult.Should().Be(result);
+    }
+}

--- a/Tests/ApplicationTests/ValidatedOptionalStructPropertyTests.cs
+++ b/Tests/ApplicationTests/ValidatedOptionalStructPropertyTests.cs
@@ -1,0 +1,22 @@
+﻿using CleanDomainValidation.Application;
+using CleanDomainValidation.Domain;
+using FluentAssertions;
+
+namespace Tests.ApplicationTests;
+
+public class ValidatedOptionalStructPropertyTests
+{
+    [Fact]
+    public void Build_ShouldReturnResultFromConstructor()
+    {
+        //Arrange
+        var result = new CanFail<int?>();
+        var property = new ValidatedOptionalStructProperty<int>(result);
+
+        //Act
+        var returnResult = property.Build();
+
+        //Assert
+        returnResult.Should().Be(result);
+    }
+}

--- a/Tests/ApplicationTests/ValidatedRequiredPropertyTests.cs
+++ b/Tests/ApplicationTests/ValidatedRequiredPropertyTests.cs
@@ -1,0 +1,22 @@
+﻿using CleanDomainValidation.Application;
+using CleanDomainValidation.Domain;
+using FluentAssertions;
+
+namespace Tests.ApplicationTests;
+
+public class ValidatedRequiredPropertyTests
+{
+    [Fact]
+    public void Build_ShouldReturnResultFromConstructor()
+    {
+        //Arrange
+        var result = new CanFail<string>();
+        var property = new ValidatedRequiredProperty<string>(result);
+
+        //Act
+        var returnResult = property.Build();
+
+        //Assert
+        returnResult.Should().Be(result);
+    }
+}

--- a/Tests/DomainTests/CanFailOfTTests.cs
+++ b/Tests/DomainTests/CanFailOfTTests.cs
@@ -5,7 +5,7 @@ namespace Tests.DomainTests;
 
 public class CanFailOfTTests
 {
-	private readonly Error _exampleError = Error.Unexpected("Code", "Message");
+	private readonly Error _exampleError = Error.Conflict("Code", "Message");
 
 	#region AbstractCanFail
 

--- a/Tests/DomainTests/CanFailOfTTests.cs
+++ b/Tests/DomainTests/CanFailOfTTests.cs
@@ -78,7 +78,7 @@ public class CanFailOfTTests
 	{
 		//Arrange
 		CanFail<string> result = new();
-		Error differentError = Error.Conflict("Code", "Message");
+		Error differentError = Error.Validation("Code", "Message");
 
 		//Act
 		result.Failed(_exampleError);

--- a/Tests/DomainTests/CanFailTests.cs
+++ b/Tests/DomainTests/CanFailTests.cs
@@ -78,7 +78,7 @@ public class CanFailTests
 	{
 		//Arrange
 		CanFail result = new();
-		Error differentError = Error.Conflict("Code", "Message");
+		Error differentError = Error.Validation("Code", "Message");
 
 		//Act
 		result.Failed(_exampleError);

--- a/Tests/DomainTests/CanFailTests.cs
+++ b/Tests/DomainTests/CanFailTests.cs
@@ -5,7 +5,7 @@ namespace Tests.DomainTests;
 
 public class CanFailTests
 {
-	private readonly Error _exampleError = Error.Unexpected("Code", "Message");
+	private readonly Error _exampleError = Error.Conflict("Code", "Message");
 
 	#region AbstractCanFail
 
@@ -146,7 +146,7 @@ public class CanFailTests
 	public void SuccessFactory_Should_ReturnNonFail()
 	{
 		//Act
-		CanFail result = CanFail.Success();
+		CanFail result = CanFail.Success;
 
 		//Assert
 		result.HasFailed.Should().BeFalse();

--- a/Tests/DomainTests/ErrorTests.cs
+++ b/Tests/DomainTests/ErrorTests.cs
@@ -94,24 +94,4 @@ public class ErrorTests
 		//Assert
 		ValidateError(error);
 	}
-
-	[Fact]
-	public void UnexpectedFactory_Should_SetConflictType()
-	{
-		//Act
-		Error error = Error.Unexpected(_exampleCode, _exampleMessage);
-
-		//Assert
-		error.Type.Should().Be(ErrorType.Unexpected);
-	}
-
-	[Fact]
-	public void UnexpectedFactory_Should_SetCodeAndMessage()
-	{
-		//Act
-		Error error = Error.Unexpected(_exampleCode, _exampleMessage);
-
-		//Assert
-		ValidateError(error);
-	}
 }


### PR DESCRIPTION
# Bug fixes
- Fixed unwanted behaviour with nested optional objects

# Enhancement / improved code quality
- just use CanFail.Success instead of CanFail.Success()